### PR TITLE
feat(): add link to typescript client

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ optional arguments:
   --engine, -e          engine to use for inference
 ```
 
+# TypeScript Client
+* Stability-ts: https://github.com/jakiestfu/stability-ts
+
 
 ## Connecting to the API in using langauges other than python
 


### PR DESCRIPTION
I created a TS client that leverages the protobuff generated files of this repo. Figured I'd share a link. The CLI was mirrored after the Python Client as well.

