### PR TITLE
Fix docstring to correct method parameter name

### DIFF
--- a/src/stability_sdk/client.py
+++ b/src/stability_sdk/client.py
@@ -230,7 +230,7 @@ class StabilityInference:
         :param seed: Seed for the random number generator.
         :param samples: Number of samples to generate.
         :param safety: Whether to use safety mode.
-        :param classifications: Classifier parameters to use.
+        :param classifiers: Classifier parameters to use.
         :return: Generator of Answer objects.
         """
         if safety and classifiers is None:


### PR DESCRIPTION
Small tweak to get the docstring to match up with the name in the parameters.