### PR TITLE
Fix StabilityInference.generate supports sequence of int as seed value (#48)

### DIFF
--- a/src/stability_sdk/client.py
+++ b/src/stability_sdk/client.py
@@ -246,7 +246,7 @@ class StabilityInference:
 
         if not seed:
             seed = [random.randrange(0, 4294967295)]
-        else:
+        elif isinstance(seed, int):
             seed = [seed]
 
         if isinstance(prompt, str):


### PR DESCRIPTION
Fixes #48

Signed-off-by: Thytu <valentin.de-matos@epitech.eu>