### PR TITLE
Removing classifier param from generation call, and deprecating safety and classifiers params

### DIFF
--- a/src/stability_sdk/client.py
+++ b/src/stability_sdk/client.py
@@ -212,6 +212,7 @@ class StabilityInference:
         seed: Union[Sequence[int], int] = 0,
         samples: int = 1,
         safety: bool = True,
+        classifiers: Optional[generation.ClassifierParameters] = None,
     ) -> Generator[generation.Answer, None, None]:
         """
         Generate images from a prompt.
@@ -228,10 +229,10 @@ class StabilityInference:
         :param steps: Number of steps to take.
         :param seed: Seed for the random number generator.
         :param samples: Number of samples to generate.
-        :param safety: Whether to use safety mode.
+        :param safety: DEPRECATED/UNUSED - Cannot be disabled.
+        :param classifiers: DEPRECATED/UNUSED - Has no effect on image generation.
         :return: Generator of Answer objects.
         """
-
         if (prompt is None) and (init_image is None):
             raise ValueError("prompt and/or init_image must be provided")
 

--- a/src/stability_sdk/client.py
+++ b/src/stability_sdk/client.py
@@ -212,7 +212,6 @@ class StabilityInference:
         seed: Union[Sequence[int], int] = 0,
         samples: int = 1,
         safety: bool = True,
-        classifiers: Optional[generation.ClassifierParameters] = None,
     ) -> Generator[generation.Answer, None, None]:
         """
         Generate images from a prompt.
@@ -230,11 +229,8 @@ class StabilityInference:
         :param seed: Seed for the random number generator.
         :param samples: Number of samples to generate.
         :param safety: Whether to use safety mode.
-        :param classifiers: Classifier parameters to use.
         :return: Generator of Answer objects.
         """
-        if safety and classifiers is None:
-            classifiers = generation.ClassifierParameters()
 
         if (prompt is None) and (init_image is None):
             raise ValueError("prompt and/or init_image must be provided")
@@ -298,7 +294,6 @@ class StabilityInference:
                 samples=samples,
                 parameters=parameters,
             ),
-            classifier=classifiers,
         )
 
         if self.verbose:


### PR DESCRIPTION
Fixes #54

Addendum to the PR originally authored by @sayanarijit : #55 

This PR keeps the `classifiers` param so that we don't break the existing contract, but explicitly deprecates the `safety` and `classifiers` params as they have zero effect on image generation.
