### PR TITLE
Moving dependencies back into setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-Pillow
-grpcio
-grpcio-tools
-python-dotenv
-protobuf==3.20.2

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,6 @@ from setuptools import setup, find_packages
 with open('README.md','r') as f:
     README = f.read()
 
-with open('requirements.txt', 'r') as f:
-    requirements = f.read().splitlines()
-
 setup(
     name='stability-sdk',
     version='0.2.4',
@@ -22,7 +19,13 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
 
-    install_requires=requirements,
+    install_requires=[
+        'Pillow',
+        'grpcio',
+        'grpcio-tools',
+        'python-dotenv',
+        'protobuf>=3.20.2,<4'
+    ],
     packages=find_packages(
         where='src',
         include=['stability_sdk*'],


### PR DESCRIPTION
Moving dependencies back into setup.py, as well as changing the pinning of `protobuf` to a version range less than 4.  This is necessary to ensure that the `protoc` generated output is compatible.

I would suggest revisiting version ranges on the other dependencies at some point, but that's out of scope for a minor or patch version bump of this lib.