### PR TITLE
Remove broken link to internal Ruby docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,6 @@ The `src` subdirectory contains pre-compiled gRPC stubs for the following langua
 
 - [Javascript/Typescript](https://github.com/Stability-AI/stability-sdk/tree/main/src/js)
 
-And guides for the following languages:
-
-* [Ruby](https://github.com/Stability-AI/stability-sdk/tree/main/src/ruby/README.md)
-
 If a language you would like to connect to the API with is not listed above, you can use the following
 protobuf definition to compile stubs for your language:
 


### PR DESCRIPTION
Removes link that erroneously points to internal Ruby docs, leaves link in community-contributed section