### PR TITLE
Point to a more up-to-date Typescript client

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ protobuf definition to compile stubs for your language:
 
 ## Community-contributed clients
 
-* Typescript client: https://github.com/jakiestfu/stability-ts
+* Typescript client: https://github.com/vpzomtrrfrt/stability-client
 * Guide to building for Ruby: https://github.com/kmcphillips/stability-sdk/blob/main/src/ruby/README.md
 
 ## DreamStudio API TOS


### PR DESCRIPTION
`stability-ts` has been [broken for a month](https://github.com/jakiestfu/stability-ts/issues/13); replacing it with a more maintained library

(Awkwardly, `stability-client` is currently broken as of a few hours ago as well; tracked in https://github.com/vpzomtrrfrt/stability-client/issues/9)