### PR TITLE
add a link to the community ruby client

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ protobuf definition to compile stubs for your language:
 
 * Typescript client: https://github.com/jakiestfu/stability-ts
 * Guide to building for Ruby: https://github.com/kmcphillips/stability-sdk/blob/main/src/ruby/README.md
+* Ruby client: https://github.com/cou929/stability-sdk-ruby
 
 ## DreamStudio API TOS
 


### PR DESCRIPTION
I've created a ruby client https://github.com/cou929/stability-sdk-ruby . And using this gem in my production environment already. So I would like to share this gem with the community as it may be helpful for others using ruby. Also, I would love to hear your feedback.