### PR TITLE
Fixing args and testing packages

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           #cache: 'pip'
       - name: Install build dependencies
         run: |

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,8 +31,14 @@ jobs:
         pip install setuptools wheel twine build
     - name: Build package
       run: |
+        rm -rf dist/*
         python -m build
-     
+    - name: Install package
+      run: |
+        pip install dist/*.whl
+    - name: Test package
+      run: |
+        python -m stability_sdk A beautiful painting of a happy robot
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,5 +1,5 @@
 # This workflow will upload a Python Package using Twine when a release is created.
-# For more information see: 
+# For more information see:
 # * https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 # * https://github.com/pypa/gh-action-pypi-publish
 
@@ -13,35 +13,34 @@ on:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-        #cache: 'pip'
-    - name: Install build dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine build
-    - name: Build package
-      run: |        
-        python -m build
-    - name: Install package
-      run: |
-        python setup.py install
-    - name: Test package
-      env: 
-        STABILITY_KEY: ${{ secrets.STABILITY_KEY }}
-      run: |
-        python -m stability_sdk A beautiful painting of a happy robot
-        python -m stability_sdk.client A nice drawing of a horse
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+          #cache: 'pip'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine build
+      - name: Build package
+        run: |
+          python -m build
+      - name: Install package
+        run: |
+          python setup.py install
+      - name: Test package
+        env:
+          STABILITY_KEY: ${{ secrets.STABILITY_KEY }}
+        run: |
+          python -m stability_sdk A beautiful painting of a happy robot
+          python -m stability_sdk.client A nice drawing of a horse
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,12 +30,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine build
     - name: Build package
-      run: |
-        rm -rf dist/*
+      run: |        
         python -m build
     - name: Install package
       run: |
-        pip install dist/*.whl
+        python setup.py install
     - name: Test package
       env: 
         STABILITY_KEY: ${{ secrets.STABILITY_KEY }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,8 +37,11 @@ jobs:
       run: |
         pip install dist/*.whl
     - name: Test package
+      env: 
+        STABILITY_KEY: ${{ secrets.STABILITY_KEY }}
       run: |
         python -m stability_sdk A beautiful painting of a happy robot
+        python -m stability_sdk.client A nice drawing of a horse
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md','r') as f:
 
 setup(
     name='stability-sdk',
-    version='0.3.0',
+    version='0.3.1',
     author='Wes Brown',
     author_email='wesbrown18@gmail.com',
     maintainer='David Marx',

--- a/src/stability_sdk/__main__.py
+++ b/src/stability_sdk/__main__.py
@@ -34,6 +34,7 @@ import stability_sdk.interfaces.gooseai.generation.generation_pb2_grpc as genera
 
 from stability_sdk.client import (
     StabilityInference,
+    process_artifacts_from_answers,
 )
 from stability_sdk.utils import (
     SAMPLERS,
@@ -98,11 +99,11 @@ parser.add_argument(
     "--sampler",
     "-A",
     type=str,
-    default="k_lms",
-    help="[k_lms] (" + ", ".join(SAMPLERS.keys()) + ")",
+    default=None,
+    help="[auto] (" + ", ".join(SAMPLERS.keys()) + ")",
 )
 parser.add_argument(
-    "--steps", "-s", type=int, default=50, help="[50] number of steps"
+    "--steps", "-s", type=int, default=None, help="[auto] number of steps"
 )
 parser.add_argument("--seed", "-S", type=int, default=0, help="random seed to use")
 parser.add_argument(
@@ -155,19 +156,20 @@ if args.mask_image:
     args.mask_image = Image.open(args.mask_image)
 
 request =  {
-    "height": cli_args.height,
-    "width": cli_args.width,
-    "start_schedule": cli_args.start_schedule,
-    "end_schedule": cli_args.end_schedule,
-    "cfg_scale": cli_args.cfg_scale,
-    "sampler": get_sampler_from_str(cli_args.sampler),
-    "steps": cli_args.steps,
-    "seed": cli_args.seed,
-    "samples": cli_args.num_samples,
-    "init_image": cli_args.init_image,
-    "mask_image": cli_args.mask_image,
+    "height": args.height,
+    "width": args.width,
+    "start_schedule": args.start_schedule,
+    "end_schedule": args.end_schedule,
+    "cfg_scale": args.cfg_scale,
+    "samples": args.num_samples,
+    "init_image": args.init_image,
+    "mask_image": args.mask_image,
 }
 
+if args.sampler:
+    request["sampler"] = get_sampler_from_str(args.sampler)
+if args.seed and args.seed > 0:
+    request["seed"] = args.seed
 
 stability_api = StabilityInference(
     STABILITY_HOST, STABILITY_KEY, engine=args.engine, verbose=True

--- a/src/stability_sdk/utils.py
+++ b/src/stability_sdk/utils.py
@@ -15,6 +15,9 @@ from PIL import Image
 import stability_sdk.interfaces.gooseai.generation.generation_pb2 as generation
 import stability_sdk.interfaces.gooseai.generation.generation_pb2_grpc as generation_grpc
 
+logger = logging.getLogger(__name__)
+logger.setLevel(level=logging.INFO)
+
 SAMPLERS: Dict[str, int] = {
     "ddim": generation.SAMPLER_DDIM,
     "plms": generation.SAMPLER_DDPM,
@@ -27,7 +30,6 @@ SAMPLERS: Dict[str, int] = {
     "k_dpmpp_2m": generation.SAMPLER_K_DPMPP_2M,
     "k_dpmpp_2s_ancestral": generation.SAMPLER_K_DPMPP_2S_ANCESTRAL
 }
-
     
 MAX_FILENAME_SZ = int(os.getenv("MAX_FILENAME_SZ", 200))
 


### PR DESCRIPTION
This fixes #124, which I noticed when testing the latest release, as well as fixing the "old" (but actually working) `client.py` args to correctly use server defaults and bringing the "new" args in line with that. We should spend some effort as mentioned in #148 on cleaning up argument parsing, unifying it between old/new structures, and general testing to avoid sending out broken code - I've added a small sanity check to the release process.

Also fixes #145.