### PR TITLE
Adding --artifact-type / -t argument : allows response artifacts to be filtered by type before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ See usage demo notebooks in ./nbs
 ```
 usage: python -m stability_sdk [-h] [--height HEIGHT] [--width WIDTH] [--start_schedule START_SCHEDULE]
                  [--end_schedule END_SCHEDULE] [--cfg_scale CFG_SCALE] [--sampler SAMPLER]
-                 [--steps STEPS] [--seed SEED] [--prefix PREFIX] [--no-store] [--num_samples NUM_SAMPLES]
-                 [--show] [--engine ENGINE] [--init_image INIT_IMAGE] [--mask_image MASK_IMAGE]
+                 [--steps STEPS] [--seed SEED] [--prefix PREFIX] [--engine ENGINE]
+                 [--num_samples NUM_SAMPLES] [--artifact_types ARTIFACT_TYPES]
+                 [--no-store] [--show] [--init_image INIT_IMAGE] [--mask_image MASK_IMAGE]
                  [prompt ...]
 
 positional arguments:
@@ -66,6 +67,8 @@ options:
   --seed SEED, -S SEED  random seed to use
   --prefix PREFIX, -p PREFIX
                         output prefixes for artifacts
+  --artifact_types ARTIFACT_TYPES, -t ARTIFACT_TYPES
+                        filter artifacts by type (ARTIFACT_IMAGE, ARTIFACT_TEXT, ARTIFACT_CLASSIFICATIONS, etc)
   --no-store            do not write out artifacts
   --num_samples NUM_SAMPLES, -n NUM_SAMPLES
                         number of samples to generate

--- a/src/stability_sdk/__main__.py
+++ b/src/stability_sdk/__main__.py
@@ -114,7 +114,7 @@ parser.add_argument(
     help="output prefixes for artifacts",
 )
 parser.add_argument(
-    "--artifact_type",
+    "--artifact_types",
     "-t",
     action='append',
     type=str,

--- a/src/stability_sdk/__main__.py
+++ b/src/stability_sdk/__main__.py
@@ -114,6 +114,13 @@ parser.add_argument(
     help="output prefixes for artifacts",
 )
 parser.add_argument(
+    "--artifact_type",
+    "-t",
+    action='append',
+    type=str,
+    help="filter artifacts by type (ARTIFACT_IMAGE, ARTIFACT_TEXT, ARTIFACT_CLASSIFICATIONS, etc)"
+)
+parser.add_argument(
     "--no-store", action="store_true", help="do not write out artifacts"
 )
 parser.add_argument(
@@ -177,7 +184,8 @@ stability_api = StabilityInference(
 
 answers = stability_api.generate(args.prompt, **request)
 artifacts = process_artifacts_from_answers(
-    args.prefix, args.prompt, answers, write=not args.no_store, verbose=True
+    args.prefix, args.prompt, answers, write=not args.no_store, verbose=True,
+    filter_types=args.artifact_types,
 )
 if args.show:
     for artifact in open_images(artifacts, verbose=True):

--- a/src/stability_sdk/client.py
+++ b/src/stability_sdk/client.py
@@ -98,7 +98,7 @@ def process_artifacts_from_answers(
             else:
                 ext = ".pb"
                 contents = artifact.SerializeToString()
-            out_p = truncate_fit(prefix, prompt, ext, int(artifact_start), idx, MAX_FILENAME_SZ)
+            out_p = truncate_fit(prefix, prompt, ext, int(artifact_start), idx, MAX_FILENAME_SZ)           
             is_allowed_type = filter_types is None or artifact_type_to_str(artifact.type) in filter_types
             if write and is_allowed_type:
                 with open(out_p, "wb") as f:
@@ -421,7 +421,7 @@ if __name__ == "__main__":
         help="output prefixes for artifacts",
     )
     parser.add_argument(
-        "--artifact_type",
+        "--artifact_types",
         "-t",
         action='append',
         type=str,

--- a/src/stability_sdk/client.py
+++ b/src/stability_sdk/client.py
@@ -98,14 +98,18 @@ def process_artifacts_from_answers(
             else:
                 ext = ".pb"
                 contents = artifact.SerializeToString()
-            out_p = truncate_fit(prefix, prompt, ext, int(artifact_start), idx, MAX_FILENAME_SZ)           
+            out_p = truncate_fit(prefix, prompt, ext, int(artifact_start), idx, MAX_FILENAME_SZ)
             is_allowed_type = filter_types is None or artifact_type_to_str(artifact.type) in filter_types
-            if write and is_allowed_type:
-                with open(out_p, "wb") as f:
-                    f.write(bytes(contents))
+            if write:
+                if is_allowed_type:
+                    with open(out_p, "wb") as f:
+                        f.write(bytes(contents))
+                        if verbose:
+                            logger.info(f"wrote {artifact_type_to_str(artifact.type)} to {out_p}")
+                else:
                     if verbose:
-                        artifact_t = artifact_type_to_str(artifact.type)
-                        logger.info(f"wrote {artifact_t} to {out_p}")
+                        logger.info(
+                            f"skipping {artifact_type_to_str(artifact.type)} due to artifact type filter")
 
             yield (out_p, artifact)
             idx += 1


### PR DESCRIPTION
## CLI Docs

```
optional arguments:
  --artifact_types ARTIFACT_TYPE, -t ARTIFACT_TYPE
                        filter artifacts by type (ARTIFACT_IMAGE, ARTIFACT_TEXT, ARTIFACT_CLASSIFICATIONS, etc)
```

## Usage Examples

Default (emit all answers)
```
python3 -m stability_sdk.client -W 512 -H 512 "A stunning house."
```

Only emit images
```
> python3 -m stability_sdk.client -t ARTIFACT_IMAGE -W 512 -H 512 "A stunning house."

2022-12-16 19:54:42,044 INFO client.py(2798971) - Opening channel to grpc.stability.ai:443
2022-12-16 19:54:42,047 INFO client.py(2798971) - Channel opened to grpc.stability.ai:443
2022-12-16 19:54:42,047 INFO client.py(2798971) - Sending request.
2022-12-16 19:54:42,515 INFO client.py(2798971) - Got keepalive f76a1814-d777-4228-91a7-f0920ac1161b in 0.47s
2022-12-16 19:54:44,454 INFO client.py(2798971) - Got keepalive f76a1814-d777-4228-91a7-f0920ac1161b in 1.94s
2022-12-16 19:54:44,545 INFO client.py(2798971) - Got answer f76a1814-d777-4228-91a7-f0920ac1161b with artifact types ['ARTIFACT_IMAGE', 'ARTIFACT_CLASSIFICATIONS', 'ARTIFACT_LATENT'] in 0.09s
2022-12-16 19:54:44,550 INFO client.py(2798971) - wrote ARTIFACT_IMAGE to generation_A stunning house._1671220484_0.png
2022-12-16 19:54:44,551 INFO client.py(2798971) - skipping ARTIFACT_CLASSIFICATIONS due to artifact type filter
2022-12-16 19:54:44,551 INFO client.py(2798971) - skipping ARTIFACT_LATENT due to artifact type filter
```

Emit images and classification scores
```
python3 -m stability_sdk.client -t ARTIFACT_IMAGE -t ARTIFACT_CLASSIFICATION -W 512 -H 512 "A stunning house."
```
