### PR TITLE
Upgrade protobuf and grpcio

### DIFF
--- a/.github/workflows/unit_testing.yaml
+++ b/.github/workflows/unit_testing.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
 
     install_requires=[
         'Pillow',
-        'grpcio==1.48.1',
-        'grpcio-tools==1.48.1',
+        'grpcio==1.52.0',
+        'grpcio-tools==1.52.0',
         'python-dotenv',
         'protobuf==3.19.5'
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'grpcio==1.52.0',
         'grpcio-tools==1.52.0',
         'python-dotenv',
-        'protobuf==3.19.5'
+        'protobuf==4.21.12'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
As mentioned in issue #176 , the SDK cannot be used with Python 3.11.

This PR:

- Upgrades to the latest version of grpc
- Upgrades to the latest version of protobuf
- Adds 3.11 to the build matrix