### PR TITLE
Simplification of 3D render mode parameters

### DIFF
--- a/src/stability_sdk/animation_ui.py
+++ b/src/stability_sdk/animation_ui.py
@@ -634,7 +634,7 @@ def ui_layout_tabs():
         accordion_from_args("Coherence", args_coherence, open=False)
         accordion_for_color(args_color)
         accordion_from_args("Depth", args_depth, exclude=["near_plane", "far_plane"], open=False)
-        accordion_from_args("Realistic 3D", args_render_3d, open=False)
+        accordion_from_args("3D render", args_render_3d, open=False)
         accordion_from_args("Inpainting", args_inpaint, open=False)
     with gr.Tab("Input"):
         ui_for_init_and_mask(args_generation)

--- a/src/stability_sdk/animation_ui.py
+++ b/src/stability_sdk/animation_ui.py
@@ -46,16 +46,16 @@ PRESETS = {
     },
     "3D render rotate": {
         "animation_mode": "3D render", "translation_x":"0:(-2)", "rotation_y":"0:(-0.8)",
-        "diffusion_cadence_curve":"0:(2)", "strength_curve":"0:(0.85)",
-        "noise_scale_curve":"0:(1.0)", "depth_model_weight":0.1,
-        "mask_min_value":"0:(0.45)", "non_inpainting_model_off_cadence":True,
+        "diffusion_cadence_curve":"0:(1)", "strength_curve":"0:(0.98)",
+        "noise_scale_curve":"0:(1.01)", "depth_model_weight":0.3,
+        "mask_min_value":"0:(0.45)", "non_inpainting_model_for_diffusion_frames":True,
     },
     "3D render explore": {
         "animation_mode": "3D render", "translation_z":"0:(10)", "translation_x":"0:(2), 20:(-2), 40:(2)",
         "rotation_y":"0:(0), 10:(1.5), 30:(-2), 50: (3)", "rotation_x":"0:(0.4)",
-        "diffusion_cadence_curve":"0:(1)", "strength_curve":"0:(0.9)",
-        "noise_scale_curve":"0:(1.0)", "depth_model_weight":0.3,
-        "mask_min_value":"0:(0.1)", "non_inpainting_model_off_cadence":True,
+        "diffusion_cadence_curve":"0:(1)", "strength_curve":"0:(0.98)",
+        "noise_scale_curve":"0:(1.01)", "depth_model_weight":0.3,
+        "mask_min_value":"0:(0.1)", "non_inpainting_model_for_diffusion_frames":True,
     },
     "Prompt interpolate": {
         "animation_mode":"2D", "interpolate_prompts":True, "locked_seed":True, "max_frames":48, 

--- a/src/stability_sdk/utils.py
+++ b/src/stability_sdk/utils.py
@@ -76,6 +76,11 @@ CAMERA_TYPES = {
     'orthographic': generation.CAMERA_ORTHOGRAPHIC,
 }
 
+RENDER_MODES = {
+    'mesh': generation.RENDER_MESH,
+    'pointcloud': generation.RENDER_POINTCLOUD,
+}
+
     
 MAX_FILENAME_SZ = int(os.getenv("MAX_FILENAME_SZ", 200))
 
@@ -135,6 +140,12 @@ def camera_type_from_string(s: str) -> generation.CameraType:
     if cam_type is None:
         raise ValueError(f"invalid camera type: {s}")
     return cam_type
+
+def render_mode_from_string(s: str) -> generation.RenderMode:
+    render_mode = RENDER_MODES.get(s.lower().strip())
+    if render_mode is None:
+        raise ValueError(f"invalid render mode: {s}")
+    return render_mode
 
 def artifact_type_to_str(artifact_type: generation.ArtifactType):
     """
@@ -365,45 +376,19 @@ def camera_pose_op(
     far_plane:float,
     fov:float,
     camera_type:str='perspective',
-    image_render_method:str='mesh',
-    image_point_radius:Optional[float]=None,
-    image_points_per_pixel:Optional[int]=None,
-    image_max_mesh_edge:Optional[float]=0.04,
-    mask_render_method:str='pointcloud',
-    mask_point_radius:Optional[float]=0.003,
-    mask_points_per_pixel:Optional[int]=4,
-    mask_max_mesh_edge:Optional[float]=None,
+    image_render_mode:str='mesh',
+    mask_render_mode:str='pointcloud',
     do_prefill:bool=True,
 ) -> generation.TransformParameters:
     camera_parameters = generation.CameraParameters(
         camera_type=camera_type_from_string(camera_type),
         near_plane=near_plane, far_plane=far_plane, fov=fov)
-    if image_render_method == "pointcloud":
-        image_render_parameters = generation.RenderParameters(
-            pointcloud_parameters=generation.PointCloudRenderParameters(
-                radius=image_point_radius, points_per_pixel=image_points_per_pixel))
-    elif image_render_method == "mesh":
-        image_render_parameters = generation.RenderParameters(
-            mesh_parameters=generation.MeshRenderParameters(
-                max_mesh_edge=image_max_mesh_edge))
-    else:
-        raise Exception("Rendering method must be one of 'pointcloud' or 'mesh'")
-    if mask_render_method == "pointcloud":
-        mask_render_parameters = generation.RenderParameters(
-            pointcloud_parameters=generation.PointCloudRenderParameters(
-                radius=mask_point_radius, points_per_pixel=mask_points_per_pixel))
-    elif mask_render_method == "mesh":
-        mask_render_parameters = generation.RenderParameters(
-            mesh_parameters=generation.MeshRenderParameters(
-                max_mesh_edge=mask_max_mesh_edge))
-    else:
-        raise Exception("Rendering method must be one of 'pointcloud' or 'mesh'")
     return generation.TransformParameters(
         camera_pose=generation.TransformCameraPose(
             world_to_view_matrix=generation.TransformMatrix(data=sum(transform, [])),
             camera_parameters=camera_parameters,
-            image_render_parameters=image_render_parameters,
-            mask_render_parameters=mask_render_parameters,
+            image_render_mode=render_mode_from_string(image_render_mode),
+            mask_render_mode=render_mode_from_string(mask_render_mode),
             do_prefill=do_prefill
         )
     )


### PR DESCRIPTION
- Removed 6 parameters: image_point_radius, image_points_per_pixel, image_max_mesh_edge, mask_point_radius, mask_points_per_pixel, mask_max_mesh_edge. Now they are calculated instead
- Mask_render_mode can be selected regardless of image_render_method or inpainting/non-inpainting model being active
- In 3D render mode the grayscale mask is multiplied by current strength value instead of max clipping

Corresponding api-interfaces PR:
https://github.com/Stability-AI/api-interfaces/pull/73