### PR TITLE
Bump grpcio dependency to 1.53.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
 
     install_requires=[
         'Pillow',
-        'grpcio==1.52.0',
-        'grpcio-tools==1.52.0',
+        'grpcio==1.53.0',
+        'grpcio-tools==1.53.0',
         'python-dotenv',
         'protobuf==4.21.12'
     ],


### PR DESCRIPTION
because 1.52.0 has been yanked

followup to https://github.com/Stability-AI/stability-sdk/pull/209