### PR TITLE
Cut pow/anima inpaint fixes

### DIFF
--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -141,8 +141,7 @@ class DepthSettings(param.Parameterized):
 
 class Rendering3dSettings(param.Parameterized):
     camera_type = param.Selector(default='perspective', objects=['perspective', 'orthographic'])
-    image_render_mode = param.Selector(default='mesh', objects=['pointcloud', 'mesh'])
-    mask_render_mode = param.Selector(default='mesh', objects=['pointcloud', 'mesh'])
+    render_mode = param.Selector(default='mesh', objects=['mesh', 'pointcloud'])
     
 class InpaintingSettings(param.Parameterized):
     non_inpainting_model_for_diffusion_frames = param.Boolean(default=False, doc="If True, for each diffusion frame, inpainting will be conducted using regular non-inpainting model to optimize number of generations.")
@@ -900,8 +899,7 @@ class Animator:
                 transform_op = camera_pose_op(
                     world_view, near, far, fov, 
                     args.camera_type,
-                    args.image_render_mode,
-                    args.mask_render_mode,
+                    render_mode=args.render_mode,
                     do_prefill=True)
             transformed_prior_frames, mask = self.api.transform_3d(self.prior_frames, depth_calc, transform_op)
             self.prior_frames.extend(transformed_prior_frames)

--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -581,7 +581,6 @@ class Animator:
 
     def render(self) -> Generator[Image.Image, None, None]:
         args = self.args
-        seed = args.seed
 
         # experimental span-based outpainting mode
         if args.cadence_spans and args.animation_mode != 'Video Input':
@@ -663,7 +662,7 @@ class Animator:
                     init_depth = results[0]
 
                 # builds set of transform ops to prepare init image for generation
-                init_image_ops = self.prepare_init_ops(init_image, frame_idx, seed)
+                init_image_ops = self.prepare_init_ops(init_image, frame_idx, args.seed)
 
                 # For in-diffusion frames instead of a full run through inpainting model and then generate call,
                 # inpainting can be done in a single call with non-inpainting model
@@ -685,7 +684,7 @@ class Animator:
                     prompts, weights, 
                     args.width, args.height, 
                     steps=adjusted_steps,
-                    seed=seed,
+                    seed=args.seed,
                     cfg_scale=args.cfg_scale,
                     sampler=sampler, 
                     init_image=init_image if init_image_ops is None else None, 
@@ -727,7 +726,7 @@ class Animator:
             yield self.emit_frame(frame_idx, out_frame)
 
             if not args.locked_seed:
-                seed += 1
+                args.seed += 1
 
     def save_settings(self, filename: str):
         settings_filepath = os.path.join(self.out_dir, filename) if self.out_dir else filename

--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -141,10 +141,11 @@ class DepthSettings(param.Parameterized):
 
 class Rendering3dSettings(param.Parameterized):
     camera_type = param.Selector(default='perspective', objects=['perspective', 'orthographic'])
-    render_mode = param.Selector(default='mesh', objects=['mesh', 'pointcloud'])
+    render_mode = param.Selector(default='mesh', objects=['mesh', 'pointcloud'], doc="Mode for image and mask rendering. 'pointcloud' is a bit faster, but 'mesh' is more stable")
+    mask_power = param.Number(default=0.3, softbounds=(0, 4), doc="Raises each mask (0, 1) value to this power. The higher the value the more changes will be applied to the nearest objects")
     
 class InpaintingSettings(param.Parameterized):
-    non_inpainting_model_for_diffusion_frames = param.Boolean(default=False, doc="If True, for each diffusion frame, inpainting will be conducted using regular non-inpainting model to optimize number of generations.")
+    use_inpainting_model = param.Boolean(default=False, doc="If True, inpainting will be performed using dedicated inpainting model. If False, inpainting will be performed with the regular model that is selected")
     inpaint_border = param.Boolean(default=False, doc="Use inpainting on top of border regions for 2D and 3D warp modes. Defaults to False")
     mask_min_value = param.String(default="0:(0.1)", doc="Mask postprocessing for non-inpainting model. Mask floor values will be clipped by this value prior to inpainting")
     mask_binarization_thr = param.Number(default=0.1, softbounds=(0,1), doc="Applied when inpainting with inpainting model. Grayscale mask values lower than this value will be set to 0, values that are higher — to 1.")
@@ -343,7 +344,6 @@ class Animator:
         self.diffusion_cadence_ofs: int = 0
         self.frame_args: FrameArgs
         self.inpaint_mask: Optional[np.ndarray] = None
-        self.inpaint_with_non_inpainting_model: bool = False
         self.key_frame_values: List[int] = []
         self.out_dir: Optional[str] = out_dir
         self.mask: Optional[np.ndarray] = None
@@ -445,8 +445,13 @@ class Animator:
             self.args.width, self.args.height = width, height
         return img
 
-    def inpaint_frame(self, frame_idx: int, image: np.ndarray, mask: np.ndarray,
-                      use_inpaint_model: bool=True) -> np.ndarray:
+    def inpaint_frame(
+        self,
+        frame_idx: int,
+        image: np.ndarray,
+        mask: np.ndarray,
+        seed: Optional[int] = None
+    ) -> np.ndarray:
         args = self.args
         steps = int(self.frame_args.steps_curve[frame_idx])
         sampler = sampler_from_string(args.sampler.lower())
@@ -458,12 +463,14 @@ class Animator:
             prompts.append(self.negative_prompt)
             weights.append(-abs(self.negative_prompt_weight))
 
-        if use_inpaint_model:
+        if args.use_inpainting_model:
+            binary_mask = self._postprocess_inpainting_mask(
+                mask, frame_idx, binarize=True, blur_radius=8)
             results = self.api.inpaint(
-                image, mask,
+                image, binary_mask,
                 prompts, weights, 
                 steps=steps,
-                seed=args.seed,
+                seed=seed if seed is not None else args.seed,
                 cfg_scale=args.cfg_scale,
                 sampler=sampler, 
                 init_strength=0.0,
@@ -472,22 +479,22 @@ class Animator:
                 preset=args.preset,
             )
         else:
-            strength = mask.min() / 255.0
-            if strength == 1.0:
-                return image
-            adjusted_steps = max(5, int(steps * (1.0 - strength))) if args.steps_strength_adj else steps
+            mask_min_value = self.frame_args.mask_min_value[frame_idx]
+            binary_mask = self._postprocess_inpainting_mask(
+                mask, frame_idx, binarize=True, min_val=mask_min_value)
+            adjusted_steps = max(5, int(steps * (1.0 - mask_min_value))) if args.steps_strength_adj else steps
             noise_scale = self.frame_args.noise_scale_curve[frame_idx]
             results = self.api.generate(
                 prompts, weights, 
                 args.width, args.height, 
                 steps=adjusted_steps,
-                seed=args.seed,
+                seed=seed if seed is not None else args.seed,
                 cfg_scale=args.cfg_scale,
-                sampler=sampler, 
-                init_image=image, 
-                init_strength=strength,
+                sampler=sampler,
+                init_image=image,
+                init_strength=mask_min_value,
                 init_noise_scale=noise_scale,
-                mask=mask,
+                mask=binary_mask,
                 masked_area_init=generation.MASKED_AREA_INIT_ORIGINAL,
                 guidance_preset=guidance,
                 preset=args.preset,
@@ -581,6 +588,7 @@ class Animator:
 
     def render(self) -> Generator[Image.Image, None, None]:
         args = self.args
+        seed = args.seed
 
         # experimental span-based outpainting mode
         if args.cadence_spans and args.animation_mode != 'Video Input':
@@ -619,27 +627,17 @@ class Animator:
                 self.inpaint_mask = self.transform_video(frame_idx)
 
             # apply inpainting
+            # If cadence is disabled and inpainting is performed using the same model as for generation,
+            # we can optimize inpaint->generate calls into a single generate call.
             if args.inpaint_border and self.inpaint_mask is not None \
-                    and not (args.non_inpainting_model_for_diffusion_frames and not self.cadence_on):
-                if args.animation_mode == '3D render':
-                    binary_mask = self._postprocess_inpainting_mask(
-                        self.inpaint_mask, frame_idx, binarize=True, min_val=0.0)
-                    if not (is_diffusion_frame and args.non_inpainting_model_for_diffusion_frames):
-                        self.inpaint_mask = binary_mask  # Grayscale mask will be needed for a non-inpainting model right after.
-                else:
-                    binary_mask = self._postprocess_inpainting_mask(
-                        self.inpaint_mask, frame_idx, binarize=True, blur_radius=8)
-                    if not (is_diffusion_frame and args.non_inpainting_model_for_diffusion_frames):
-                        self.inpaint_mask = binary_mask
-                    # binary_mask = self.inpaint_mask
+                    and (self.cadence_on or args.use_inpainting_model):
                 for i in range(len(self.prior_frames)):
-                    # The earliest prior frame will be popped right after the generation step, so this inpainting call for it would be redundant.
+                    # The earliest prior frame will be popped right after the generation step, so its inpainting would be redundant.
                     if self.cadence_on and is_diffusion_frame and i==0:
                         continue
                     self.prior_frames[i] = self.inpaint_frame(
-                        frame_idx, self.prior_frames[i],
-                        binary_mask,
-                        use_inpaint_model=True)
+                        frame_idx, self.prior_frames[i], self.inpaint_mask,
+                        seed=None if args.use_inpainting_model else seed)
 
             # apply mask to transformed prior frames
             self.next_mask()
@@ -652,6 +650,7 @@ class Animator:
             # either run diffusion or emit an inbetween frame
             if is_diffusion_frame:
                 init_image = self.prior_frames[-1] if len(self.prior_frames) and strength > 0 else None
+                init_strength = strength if init_image is not None else 0.0
 
                 # mix video frame into init image
                 mix_in = self.frame_args.video_mix_in_curve[frame_idx]
@@ -667,32 +666,32 @@ class Animator:
                     init_depth = results[0]
 
                 # builds set of transform ops to prepare init image for generation
-                init_image_ops = self.prepare_init_ops(init_image, frame_idx, args.seed)
+                init_image_ops = self.prepare_init_ops(init_image, frame_idx, seed)
 
                 # For in-diffusion frames instead of a full run through inpainting model and then generate call,
                 # inpainting can be done in a single call with non-inpainting model
-                do_inpainting = args.non_inpainting_model_for_diffusion_frames \
+                do_inpainting = not self.cadence_on and not args.use_inpainting_model \
                         and self.inpaint_mask is not None \
                         and (args.inpaint_border or args.animation_mode == '3D render')
-                start_diffusion_from = min(strength, self.frame_args.mask_min_value[frame_idx] if do_inpainting else 1.0)
                 if do_inpainting:
+                    mask_min_value = self.frame_args.mask_min_value[frame_idx]
+                    init_strength = min(strength, mask_min_value) 
                     self.inpaint_mask = self._postprocess_inpainting_mask(
                         self.inpaint_mask, frame_idx, 
-                        mask_pow=0.3 if args.animation_mode == '3D render' else None,
-                        blur_radius=0,
-                        mask_multiplier=strength)
+                        mask_pow=args.mask_power if args.animation_mode == '3D render' else None,
+                        mask_multiplier=strength,
+                        min_val=mask_min_value)
 
                 # generate the next frame
                 sampler = sampler_from_string(args.sampler.lower())
                 guidance = guidance_from_string(args.clip_guidance)
                 noise_scale = self.frame_args.noise_scale_curve[frame_idx]
-                adjusted_steps = int(max(5, steps*(1.0-start_diffusion_from))) if args.steps_strength_adj else int(steps)
-                init_strength = (strength if not do_inpainting else start_diffusion_from) if init_image is not None else 0.0
+                adjusted_steps = int(max(5, steps*(1.0-init_strength))) if args.steps_strength_adj else int(steps)
                 generate_request = self.api.generate(
                     prompts, weights, 
                     args.width, args.height, 
                     steps=adjusted_steps,
-                    seed=args.seed,
+                    seed=seed,
                     cfg_scale=args.cfg_scale,
                     sampler=sampler, 
                     init_image=init_image if init_image_ops is None else None, 
@@ -733,7 +732,7 @@ class Animator:
             yield self.emit_frame(frame_idx, out_frame)
 
             if not args.locked_seed:
-                args.seed += 1
+                seed += 1
 
     def save_settings(self, filename: str):
         settings_filepath = os.path.join(self.out_dir, filename) if self.out_dir else filename
@@ -908,7 +907,7 @@ class Animator:
                     world_view, near, far, fov, 
                     args.camera_type,
                     render_mode=args.render_mode,
-                    do_prefill=True)
+                    do_prefill=not args.use_inpainting_model)
             transformed_prior_frames, mask = self.api.transform_3d(self.prior_frames, depth_calc, transform_op)
             self.prior_frames.extend(transformed_prior_frames)
             return mask[0] if isinstance(mask, list) else mask
@@ -948,10 +947,10 @@ class Animator:
             blur_radius: Optional[int] = None,
             min_val: Optional[float] = None
         ) -> np.ndarray:
-        # Being applied in 3D render mode. Changing magnitude of values of the mask. Camera pose transform operation returns
-        # a mask which pixel values encode how much signal from the previous frame is present there. But a mapping from 
-        # the signal presence values to the optimal per-pixel init strength is unknown, and roughly guessed as a per-pixel power fuction.
-        # Leaving pow=1 results in close objects changing to a greater extent than a natural emergence of fine details when approaching an object.
+        # Being applied in 3D render mode. Camera pose transform operation returns a mask which pixel values encode
+        # how much signal from the previous frame is present there. But a mapping from the signal presence values
+        # to the optimal per-pixel init strength is unknown, and roughly guessed as a per-pixel power fuction.
+        # Leaving mask_pow=1 results in near objects changing to a greater extent than a natural emergence of fine details when approaching an object.
         if mask_pow is not None:
             mask = (np.power(mask / 255., mask_pow) * 255).astype(np.uint8)
         if mask_multiplier is not None:
@@ -962,8 +961,9 @@ class Animator:
             kernel_size = blur_radius*2+1
             mask = cv2.erode(mask, np.ones((kernel_size, kernel_size), np.uint8))
             mask = cv2.GaussianBlur(mask, (kernel_size, kernel_size), 0)
-        mask_min_value = self.frame_args.mask_min_value[frame_idx] if min_val is None else min_val
-        return mask.clip(255 * mask_min_value, 255).astype(np.uint8)
+        if min_val is not None:
+            mask = mask.clip(255 * min_val, 255).astype(np.uint8)
+        return mask
     
     def _span_render_frame(
         self, 
@@ -1068,7 +1068,9 @@ class Animator:
 
         # inpaint the backwards frame
         if not np.all(backward_masks[0]):
-            backward_frames[0] = self.inpaint_frame(start, backward_frames[0], backward_masks[0])
+            backward_frames[0] = self.inpaint_frame(
+                start, backward_frames[0], backward_masks[0],
+                seed=None if args.use_inpainting_model else seed)
 
         # yield the final frames blending from forward to backward
         for idx, (frame_fwd, frame_bwd) in enumerate(zip(forward_frames, backward_frames)):

--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -147,7 +147,7 @@ class Rendering3dSettings(param.Parameterized):
 class InpaintingSettings(param.Parameterized):
     use_inpainting_model = param.Boolean(default=False, doc="If True, inpainting will be performed using dedicated inpainting model. If False, inpainting will be performed with the regular model that is selected")
     inpaint_border = param.Boolean(default=False, doc="Use inpainting on top of border regions for 2D and 3D warp modes. Defaults to False")
-    mask_min_value = param.String(default="0:(0.1)", doc="Mask postprocessing for non-inpainting model. Mask floor values will be clipped by this value prior to inpainting")
+    mask_min_value = param.String(default="0:(0.25)", doc="Mask postprocessing for non-inpainting model. Mask floor values will be clipped by this value prior to inpainting")
     mask_binarization_thr = param.Number(default=0.1, softbounds=(0,1), doc="Applied when inpainting with inpainting model. Grayscale mask values lower than this value will be set to 0, values that are higher — to 1.")
     save_inpaint_masks = param.Boolean(default=False)
 
@@ -465,7 +465,7 @@ class Animator:
 
         if args.use_inpainting_model:
             binary_mask = self._postprocess_inpainting_mask(
-                mask, frame_idx, binarize=True, blur_radius=8)
+                mask, frame_idx, binarize=True)
             results = self.api.inpaint(
                 image, binary_mask,
                 prompts, weights, 
@@ -680,6 +680,7 @@ class Animator:
                         self.inpaint_mask, frame_idx, 
                         mask_pow=args.mask_power if args.animation_mode == '3D render' else None,
                         mask_multiplier=strength,
+                        blur_radius=None,
                         min_val=mask_min_value)
 
                 # generate the next frame
@@ -944,7 +945,7 @@ class Animator:
             mask_pow: Optional[float] = None,
             mask_multiplier: Optional[float] = None,
             binarize: bool = False,
-            blur_radius: Optional[int] = None,
+            blur_radius: Optional[int] = 8,
             min_val: Optional[float] = None
         ) -> np.ndarray:
         # Being applied in 3D render mode. Camera pose transform operation returns a mask which pixel values encode

--- a/src/stability_sdk/animation_ui.py
+++ b/src/stability_sdk/animation_ui.py
@@ -52,26 +52,34 @@ PRESETS = {
         "strength_curve":"0:(0.7)", "translation_z":"0:(1.0)",
     },
     "3D render rotate": {
-        "animation_mode": "3D render", "translation_x":"0:(-2)", "rotation_y":"0:(-0.8)",
-        "diffusion_cadence_curve":"0:(1)", "strength_curve":"0:(0.98)",
-        "noise_scale_curve":"0:(1.01)", "depth_model_weight":0.3,
-        "mask_min_value":"0:(0.45)", "non_inpainting_model_for_diffusion_frames":True,
+        "animation_mode": "3D render", "depth_model_weight":1.0,
+        "translation_x":"0:(-3.5)", "rotation_y":"0:(1.7)", "translation_z":"0:(-0.5)",
+        "diffusion_cadence_curve":"0:(1)", "strength_curve":"0:(0.96)", "noise_scale_curve":"0:(1.01)",
+        "mask_min_value":"0:(0.35)", "use_inpainting_model":False, "preset": "anime",
+        "animation_prompts": "{\n0:\"beautiful portrait of a ninja in a sunflower field\"\n}"
     },
     "3D render explore": {
         "animation_mode": "3D render", "translation_z":"0:(10)", "translation_x":"0:(2), 20:(-2), 40:(2)",
         "rotation_y":"0:(0), 10:(1.5), 30:(-2), 50: (3)", "rotation_x":"0:(0.4)",
         "diffusion_cadence_curve":"0:(1)", "strength_curve":"0:(0.98)",
-        "noise_scale_curve":"0:(1.01)", "depth_model_weight":0.3,
-        "mask_min_value":"0:(0.1)", "non_inpainting_model_for_diffusion_frames":True,
+        "noise_scale_curve":"0:(1.01)", "depth_model_weight":1.0,
+        "mask_min_value":"0:(0.1)", "use_inpainting_model":False, "preset":"3d-model",
+        "animation_prompts": "{\n0:\"Phantasmagoric carnival, carnival attractions shifting and changing, bizarre surreal circus\"\n}"
     },
     "Prompt interpolate": {
         "animation_mode":"2D", "interpolate_prompts":True, "locked_seed":True, "max_frames":48, 
         "strength_curve":"0:(0)", "diffusion_cadence_curve":"0:(4)", "cadence_interp":"film",
         "clip_guidance":"None", "animation_prompts": "{\n0:\"a photo of a cute cat\",\n24:\"a photo of a cute dog\"\n}"
     },
+    "Translate and inpaint": {
+        "animation_mode":"2D", "inpaint_border":True, "use_inpainting_model":False, "translation_x":"0:(-20)", 
+        "diffusion_cadence_curve":"0:(3)", "strength_curve":"0:(0.85)", "noise_scale_curve":"0:(1.01)", "border":"reflect",
+        "animation_prompts": "{\n0:\"Mystical pumpkin field landscapes on starry Halloween night, pop surrealism art\"\n}"
+    },
     "Outpaint": {
         "animation_mode":"2D", "diffusion_cadence_curve":"0:(24)", "cadence_spans":True, "strength_curve":"0:(0.75)",
-        "inpaint_border":True, "zoom":"0:(0.95)", "animation_prompts": "{\n0:\"an ancient and magical portal, in a fantasy corridor\"\n}"
+        "inpaint_border":True, "use_inpainting_model":True, "zoom":"0:(0.95)",
+        "animation_prompts": "{\n0:\"an ancient and magical portal, in a fantasy corridor\"\n}"
     },
     "Video Stylize": {
         "animation_mode":"Video Input", "model":"stable-diffusion-depth-v2-0", "locked_seed":True, 

--- a/src/stability_sdk/api.py
+++ b/src/stability_sdk/api.py
@@ -130,7 +130,6 @@ class Context:
         init_depth: Optional[np.ndarray] = None,
         mask: Optional[np.ndarray] = None,
         masked_area_init: generation.MaskedAreaInit = generation.MASKED_AREA_INIT_ORIGINAL,
-        mask_fixup: bool = True,
         guidance_preset: generation.GuidancePreset = generation.GUIDANCE_PRESET_NONE,
         guidance_cuts: int = 0,
         guidance_strength: float = 0.0,
@@ -154,7 +153,6 @@ class Context:
         :param init_noise_scale: Scale of the initial noise
         :param mask: Mask to use (0 for pixels to change, 255 for pixels to keep)
         :param masked_area_init: How to initialize the masked area
-        :param mask_fixup: Whether to restore the unmasked area after diffusion
         :param guidance_preset: Preset to use for CLIP guidance
         :param guidance_cuts: Number of cuts to use with CLIP guidance
         :param guidance_strength: Strength of CLIP guidance
@@ -191,10 +189,6 @@ class Context:
 
         results = self._run_request(self._generate, request)
 
-        # optionally force pixels in unmasked areas not to change
-        if init_image is not None and mask is not None and mask_fixup:
-            results[generation.ARTIFACT_IMAGE] = [image_mix(image, init_image, mask) for image in results[generation.ARTIFACT_IMAGE]]
-
         return results
 
     def get_user_info(self) -> Tuple[float, str]:
@@ -220,7 +214,6 @@ class Context:
         init_strength: float = 0.0,
         init_noise_scale: Optional[float] = None,
         masked_area_init: generation.MaskedAreaInit = generation.MASKED_AREA_INIT_ZERO,
-        mask_fixup: bool = False,
         guidance_preset: generation.GuidancePreset = generation.GUIDANCE_PRESET_NONE,
         guidance_cuts: int = 0,
         guidance_strength: float = 0.0,
@@ -241,7 +234,6 @@ class Context:
         :param init_strength: Strength of the initial image
         :param init_noise_scale: Scale of the initial noise
         :param masked_area_init: How to initialize the masked area
-        :param mask_fixup: Whether to restore the unmasked area after diffusion
         :param guidance_preset: Preset to use for CLIP guidance
         :param guidance_cuts: Number of cuts to use with CLIP guidance
         :param guidance_strength: Strength of CLIP guidance
@@ -267,10 +259,6 @@ class Context:
 
         request = generation.Request(engine_id=self._inpaint.engine_id, prompt=p, image=image_params, extras=extras)        
         results = self._run_request(self._inpaint, request)
-
-        # optionally force pixels in unmasked areas not to change
-        if mask_fixup:
-            results[generation.ARTIFACT_IMAGE] = [image_mix(res_image, image, mask) for res_image in results[generation.ARTIFACT_IMAGE]]
 
         return results
 

--- a/src/stability_sdk/utils.py
+++ b/src/stability_sdk/utils.py
@@ -330,8 +330,7 @@ def camera_pose_op(
     far_plane:float,
     fov:float,
     camera_type:str='perspective',
-    image_render_mode:str='mesh',
-    mask_render_mode:str='pointcloud',
+    render_mode:str='mesh',
     do_prefill:bool=True,
 ) -> generation.TransformParameters:
     camera_parameters = generation.CameraParameters(
@@ -341,8 +340,7 @@ def camera_pose_op(
         camera_pose=generation.TransformCameraPose(
             world_to_view_matrix=generation.TransformMatrix(data=sum(transform, [])),
             camera_parameters=camera_parameters,
-            image_render_mode=render_mode_from_string(image_render_mode),
-            mask_render_mode=render_mode_from_string(mask_render_mode),
+            render_mode=render_mode_from_string(render_mode),
             do_prefill=do_prefill
         )
     )


### PR DESCRIPTION
- remove non_inpainting_model_for_diffusion_frames param
- add mask_power param for 3D render mode mask postprocessing
- add use_inpainting_model param
- by default inpainting is done using non-inpainting models
- mask postprocessing inside inpaint function
- seed is not fixed for inpainting with non-inpainting model
- cadence_span mode supports non-inpainting model inpainting