### PR TITLE
Cut pow/resume and postprocess video

### DIFF
--- a/nbs/animation.ipynb
+++ b/nbs/animation.ipynb
@@ -68,7 +68,8 @@
         "\n",
         "\n",
         "from stability_sdk.api import Context\n",
-        "from stability_sdk.animation import AnimationArgs, Animator, create_video_from_frames\n",
+        "from stability_sdk.animation import AnimationArgs, Animator\n",
+        "from stability_sdk.utils import create_video_from_frames\n",
         "\n",
         "\n",
         "# Connect to Stability API\n",
@@ -283,9 +284,9 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "venv",
+      "display_name": "client",
       "language": "python",
-      "name": "python3"
+      "name": "client"
     },
     "language_info": {
       "codemirror_mode": {

--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -147,7 +147,7 @@ class InpaintingSettings(param.Parameterized):
     use_inpainting_model = param.Boolean(default=False, doc="If True, inpainting will be performed using dedicated inpainting model. If False, inpainting will be performed with the regular model that is selected")
     inpaint_border = param.Boolean(default=False, doc="Use inpainting on top of border regions for 2D and 3D warp modes. Defaults to False")
     mask_min_value = param.String(default="0:(0.25)", doc="Mask postprocessing for non-inpainting model. Mask floor values will be clipped by this value prior to inpainting")
-    mask_binarization_thr = param.Number(default=0.15, softbounds=(0,1), doc="Applied when inpainting with inpainting model. Grayscale mask values lower than this value will be set to 0, values that are higher — to 1.")
+    mask_binarization_thr = param.Number(default=0.5, softbounds=(0,1), doc="Grayscale mask values lower than this value will be set to 0, values that are higher — to 1.")
     save_inpaint_masks = param.Boolean(default=False)
 
 class VideoInputSettings(param.Parameterized):

--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -215,40 +215,6 @@ def args_to_dict(args):
     else:
         raise NotImplementedError(f"Unsupported arguments object type: {type(args)}")
 
-def create_video_from_frames(frames_path: str, mp4_path: str, fps: int=24, reverse: bool=False):
-    """
-    Convert a series of image frames to a video file using ffmpeg.
-
-    :param frames_path: The path to the directory containing the image frames named frame_00000.png, frame_00001.png, etc.
-    :param mp4_path: The path to save the output video file.
-    :param fps: The frames per second for the output video. Default is 24.
-    :param reverse: A flag to reverse the order of the frames in the output video. Default is False.
-    """
-
-    cmd = [
-        'ffmpeg',
-        '-y',
-        '-vcodec', 'png',
-        '-r', str(fps),
-        '-start_number', str(0),
-        '-i', os.path.join(frames_path, "frame_%05d.png"),
-        '-c:v', 'libx264',
-        '-vf',
-        f'fps={fps}',
-        '-pix_fmt', 'yuv420p',
-        '-crf', '17',
-        '-preset', 'veryslow',
-        mp4_path
-    ]
-    if reverse:
-        cmd.insert(-1, '-vf')
-        cmd.insert(-1, 'reverse')    
-
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    _, stderr = process.communicate()
-    if process.returncode != 0:
-        raise RuntimeError(stderr)
-
 def cv2_to_pil(cv2_img: np.ndarray) -> Image.Image:
     """Convert a cv2 BGR ndarray to a PIL Image"""
     return Image.fromarray(cv2_img[:, :, ::-1])

--- a/src/stability_sdk/animation.py
+++ b/src/stability_sdk/animation.py
@@ -487,6 +487,7 @@ class Animator:
             mask_min_value = self.frame_args.mask_min_value[frame_idx]
             binary_mask = self._postprocess_inpainting_mask(
                 mask, frame_idx, binarize=True, min_val=mask_min_value, blur_radius=mask_blur_radius)
+            mask_min_value = np.array(binary_mask).min() / 255.  # Mask's actual min value might be higher than the threshold
             adjusted_steps = max(5, int(steps * (1.0 - mask_min_value))) if args.steps_strength_adj else steps
             noise_scale = self.frame_args.noise_scale_curve[frame_idx]
             results = self.api.generate(
@@ -972,7 +973,7 @@ class Animator:
         if mask_multiplier is not None:
             mask = (mask * mask_multiplier).astype(np.uint8)
         if binarize:
-            np.where(mask > self.args.mask_binarization_thr * 255, 255, 0).astype(np.uint8)
+            mask = np.where(mask > self.args.mask_binarization_thr * 255, 255, 0).astype(np.uint8)
         if blur_radius is not None:
             kernel_size = blur_radius*2+1
             mask = cv2.erode(mask, np.ones((kernel_size, kernel_size), np.uint8))

--- a/src/stability_sdk/animation_ui.py
+++ b/src/stability_sdk/animation_ui.py
@@ -315,7 +315,7 @@ def post_process_tab():
                 suffix += "_x2"
                 upscale_dir = os.path.join(outdir, "upscale") 
                 os.makedirs(upscale_dir, exist_ok=True)
-                frame_paths = glob.glob(os.path.join(outdir, "frame_*.png"))
+                frame_paths = sorted(glob.glob(os.path.join(outdir, "frame_*.png")))
                 num_frames = len(frame_paths)
                 if not can_skip_upscale:
                     remove_frames_from_path(upscale_dir)

--- a/src/stability_sdk/animation_ui.py
+++ b/src/stability_sdk/animation_ui.py
@@ -523,10 +523,10 @@ def project_tab():
     button_load_projects.click(load_projects, outputs=[button_load_projects, projects_dropdown, project_row_create, project_row_import, project_row_load, header])
     button_delete_project.click(delete_project, inputs=projects_dropdown, outputs=[projects_dropdown, project_row_load, project_data_log])
 
-def remove_frames_from_path(path, leave_first=None):
+def remove_frames_from_path(path: str, leave_first: Optional[int]=None):
     if os.path.isdir(path):
         frames = sorted(glob.glob(os.path.join(path, "frame_*.png")))
-        if leave_first is not None:
+        if leave_first:
             frames = frames[leave_first:]
         for f in frames:
             os.remove(f)

--- a/src/stability_sdk/animation_ui.py
+++ b/src/stability_sdk/animation_ui.py
@@ -37,10 +37,13 @@ from .animation import (
     Rendering3dSettings,
     VideoInputSettings,
     VideoOutputSettings,
-    create_video_from_frames,
     interpolate_frames
 )
-from .utils import extract_frames_from_video, interpolate_mode_from_string
+from .utils import (
+    create_video_from_frames,
+    extract_frames_from_video,
+    interpolate_mode_from_string
+)
 
 
 DATA_VERSION = "0.1"

--- a/src/stability_sdk/utils.py
+++ b/src/stability_sdk/utils.py
@@ -208,6 +208,40 @@ def artifact_type_to_string(artifact_type: generation.ArtifactType):
         )
         return "ARTIFACT_UNRECOGNIZED"
 
+def create_video_from_frames(frames_path: str, mp4_path: str, fps: int=24, reverse: bool=False):
+    """
+    Convert a series of image frames to a video file using ffmpeg.
+
+    :param frames_path: The path to the directory containing the image frames named frame_00000.png, frame_00001.png, etc.
+    :param mp4_path: The path to save the output video file.
+    :param fps: The frames per second for the output video. Default is 24.
+    :param reverse: A flag to reverse the order of the frames in the output video. Default is False.
+    """
+
+    cmd = [
+        'ffmpeg',
+        '-y',
+        '-vcodec', 'png',
+        '-r', str(fps),
+        '-start_number', str(0),
+        '-i', os.path.join(frames_path, "frame_%05d.png"),
+        '-c:v', 'libx264',
+        '-vf',
+        f'fps={fps}',
+        '-pix_fmt', 'yuv420p',
+        '-crf', '17',
+        '-preset', 'veryslow',
+        mp4_path
+    ]
+    if reverse:
+        cmd.insert(-1, '-vf')
+        cmd.insert(-1, 'reverse')    
+
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    if process.returncode != 0:
+        raise RuntimeError(stderr)
+
 def extract_frames_from_video(video_path: str, frames_subdir: str='frames'):
     """
     Extracts all frames from a video to a subdirectory of the video's parent folder.

--- a/src/stability_sdk/utils.py
+++ b/src/stability_sdk/utils.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import os
+import subprocess
 
 from PIL import Image
 from typing import Dict, Generator, Optional, Sequence, Tuple, Type, TypeVar, Union
@@ -206,6 +207,29 @@ def artifact_type_to_string(artifact_type: generation.ArtifactType):
             "If updating the client does not make this warning message go away, please report this behavior to https://github.com/Stability-AI/stability-sdk/issues/new"
         )
         return "ARTIFACT_UNRECOGNIZED"
+
+def extract_frames_from_video(video_path: str, frames_subdir: str='frames'):
+    """
+    Extracts all frames from a video to a subdirectory of the video's parent folder.
+    :param video_path: A path to the video.
+    :param frames_subdir: Name of the subdirectory to save the frames into.
+    :return: The frames subdirectory path.
+    """
+    out_dir = os.path.join(os.path.dirname(video_path), frames_subdir)
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
+    
+    cmd = [
+        'ffmpeg',
+        '-i', video_path,
+        os.path.join(out_dir, "frame_%05d.png"),
+    ]
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    if process.returncode != 0:
+        raise RuntimeError(stderr)
+
+    return out_dir
 
 def image_mix(img_a: Image.Image, img_b: Image.Image, ratio: Union[float, Image.Image]) -> Image.Image:
     """


### PR DESCRIPTION
1. resume option in gradio notebook
- Default behaviour is the same -- all generated frames from the previous run will be deleted when press render button. But if `resume` option is selected, the animation will be continued from the last existing frame if `resume_from=-1`, or any specific positive frame number. 
- These two parameters are the first one in the `Input` tab, because they kind of overwrite init image, but it's up for discussion
2. Postprocessing can be done for any specified videofile
- Frames are extracted to a 'frames' subdirectory near the videofile; then processed just like a generated frames project dir. 
- I've decided to go with videofiles and not directories because it's more universal and a directory way obliges to have specific image name format in it.
- This is also the first two options in the `Post` tab because it is input, but it's also up for a discussion.
- Gradio components `File` and `UploadButton` allow to use file manager to navigate to a video instead of specifying its path, but for some reason they both were freezing the notebook rendering for me. I haven't tried running it in colab, and haven't played around it much, but decided to go for a simpler (although a bit less convenient) solution, especially since the `video_input_path` is a Text also.
3. upscale frames in correct order