### PR TITLE
Run unit tests on PRs

### DIFF
--- a/.github/workflows/unit_testing.yaml
+++ b/.github/workflows/unit_testing.yaml
@@ -1,6 +1,6 @@
 name: run unit tests
 
-on: [push, workflow_dispatch]
+on: [push, workflow_dispatch, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Unit tests currently only trigger on push, which means they won't run for PRs from forks (as no push to our repo happens).