### PR TITLE
Fix Lib Versions

### DIFF
--- a/.github/workflows/unit_testing.yaml
+++ b/.github/workflows/unit_testing.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md','r') as f:
 
 setup(
     name='stability-sdk',
-    version='0.8.5',
+    version='0.8.6',
     author='Stability AI',
     author_email='support@stability.ai',
     maintainer='Stability AI',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'grpcio-tools>=1.53.0,<1.64.0',
         'python-dotenv',
         'param',
-        'protobuf==4.21.12'
+        'protobuf>=4.21.12,<6.0.0'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
It seems #273 may not have actually worked for all configurations, so this PR is for any further fixes. The first one is to increase the protobuf range, since the version in `setup.py` didn't actually work with the latest versions of grpcio-tools (see [this failed run](https://github.com/Stability-AI/stability-sdk/actions/runs/8987896816/job/24687481802)). 