### PR TITLE
Remove python 3.7 support because it reached eol in 2023

### DIFF
--- a/.github/workflows/unit_testing.yaml
+++ b/.github/workflows/unit_testing.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Github actions using ubuntu-latest failed with python 3.7. This is because python 3.7 reached end-of-life in 2023 and is not supported in Ubuntu 24.04 x64.

https://github.com/actions/setup-python/issues/962#issuecomment-2414418045

This PR removes tests that run with python 3.7.