### PR TITLE
Widen grpcio pin from <1.64.0 to <1.79.0 so it works on Python 3.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         'Pillow',
-        'grpcio>=1.53.0,<1.64.0',
-        'grpcio-tools>=1.53.0,<1.64.0',
+        'grpcio>=1.53.0,<1.79.0',
+        'grpcio-tools>=1.53.0,<1.79.0',
         'python-dotenv',
         'param',
         'protobuf>=4.21.12,<6.0.0'


### PR DESCRIPTION
grpcio>=1.53.0,<1.64.0 has no pre-built wheels for Python 3.14. pip falls back to building from source, which fails during C++ compilation of grpcio. It's a pretty frustrating experience for people using newer versions of python.

The fix:
Widen the upper bound to <1.79.0 (current stable line). grpcio 1.75.1+ ships wheels for Python 3.14, so pip resolves a binary wheel instead of attempting a source build.

This should also resolve a lot of the vulnerabilities with older grpcio versions

The lower bound (>=1.53.0) is unchanged.

I've tested locally:
pip install stability-sdk resolves and installs cleanly on Python 3.14.0b1 (macOS arm64).
